### PR TITLE
Provide the ability to log errors at source

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,8 @@ Example: passing thrown string errors to the client while masking javascript err
   });
 ```
 
+You can provide a function called `$logError` in the `$global` object to record any true javascript errors (with `.stack`) when they occur.  For proper logging it is important to capture the error at source, as the dependencies might be optional - in which case the error never reaches the original request.
+
 ### making arguments optional with the underscore prefix
 If any argument to a function resolves as a rejected promise (i.e. errored) then the function will not run and simply be rejected as well.  But sometimes we want to continue nevertheless.  Any argument to any function can be made optional by prefixing the argument name with an underscore.   If the resolution of the optional argument returns a rejected promise (or the optional argument does not exist), then the value of this argument to the function will simply be `undefined`.   
 ```js

--- a/clues.js
+++ b/clues.js
@@ -121,7 +121,13 @@
     var value = inputs
       .then(function(args) {
         duration = new Date();
-        return fn.apply(logic || {}, args);
+        try {
+          return fn.apply(logic || {}, args);
+        } catch(e) {
+          if (e && e.stack && typeof $global.$logError === 'function')
+            $global.$logError(e);
+          throw e;
+        }
       })
       .then(function(d) {
         if (typeof $global.$duration === 'function')

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clues",
-  "version": "3.5.1",
+  "version": "3.5.2",
   "description": "Lightweight logic tree solver using promises.",
   "keywords": [
     "asynchronous",

--- a/test/error-test.js
+++ b/test/error-test.js
@@ -95,6 +95,43 @@ describe('error',function() {
         });
       });
     });
+
+    describe('$logError',function() {
+      var logic = {
+          stack_error: function() { throw new Error('error');},
+          rejection: function() { throw 'error';},
+          optional: function(_stack_error,_rejection) {
+            return 'OK';
+          }
+        };
+
+      it('should log an error with stack',function() {
+        var facts = Object.create(logic),error;          
+        return clues(facts,'stack_error',{$logError:function(e) {error = e;}})
+          .catch(Object)
+          .then(function() {
+            assert.equal(error.message,'error');
+          });
+      });
+
+      it('should not log an error with no stack',function() {
+        var facts = Object.create(logic),error;          
+        return clues(facts,'rejection',{$logError:function(e) {error = e;}})
+          .catch(Object)
+          .then(function() {
+            assert.equal(error,undefined);
+          });
+      });
+      
+      it('should log an error even if only used optionally',function() {
+        var facts = Object.create(logic),error;          
+        return clues(facts,'optional',{$logError:function(e) {error = e;}})
+          .catch(Object)
+          .then(function() {
+            assert.equal(error.message,'error');
+          });
+      });
+    });
   });
 });
 


### PR DESCRIPTION
By defining a `$logError` function in the `$global` object
closes #25 