### PR TITLE
Fix: duration not reported on errors

### DIFF
--- a/clues.js
+++ b/clues.js
@@ -130,9 +130,11 @@
           throw e;
         });
       })
-      .then(function(d) {
+      .finally(function() {
         if (typeof $global.$duration === 'function')
           $global.$duration(fullref,[(new Date()-duration),(new Date())-wait]);
+      })
+      .then(function(d) {
         return (typeof d == 'string' || typeof d == 'number') ? d : clues(logic,d,$global,caller,fullref);
       })
       .catch(function(e) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clues",
-  "version": "3.5.7",
+  "version": "3.5.8",
   "description": "Lightweight logic tree solver using promises.",
   "keywords": [
     "asynchronous",


### PR DESCRIPTION
By moving the `$global.duration` into a `.finally` we ensure this is executed regardless of resolved/rejected status