### PR TITLE
Switch inject to lazy

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clues",
-  "version": "3.5.13",
+  "version": "3.5.14",
   "description": "Lightweight logic tree solver using promises.",
   "keywords": [
     "asynchronous",

--- a/test/inject-test.js
+++ b/test/inject-test.js
@@ -14,7 +14,8 @@ var Logic = {
       userid: {value: userid}
     });
   },
-  userid : ['input.userid',String]
+  userid : ['input.userid',String],
+  never_traversed : {}
 };
 
 
@@ -25,7 +26,11 @@ var injected = function($global) {
     },
     'db.user' : function(userid) {
       return { desc: 'this is an injected response', userid: userid};
-    }
+    },
+    'impossible.to.reach' : 42,
+    'possible' : {},
+    'possible.value': 42,
+    'never_traversed.value' : 11
   },$global);
 };
 
@@ -34,6 +39,29 @@ describe('inject',function() {
     return clues(injected,'db.user',{input:{userid:'johndoe'}})
       .then(function(d) {
         assert.equal(d.userid,'test_johndoe');
+      });
+  });
+
+  it('allows sequential injections',function() {
+    return clues(injected,'possible.value',{})
+      .then(function(d) {
+        assert.equal(d,42);
+      });
+  });
+
+  it('ignores base paths that do not exists',function() {
+    return clues(injected,'impossible.to.reach',{})
+      .then(function() {
+        throw 'SHOULD_ERROR';
+      },function(e) {
+        assert.equal(e.message,'impossible not defined');
+      });
+  });
+
+  it('does not execute injected paths that are not traversed',function() {
+    return clues({},injected)
+      .then(function(injected) {
+        assert(typeof injected.never_traversed === 'function');
       });
   });
 });

--- a/util/inject.js
+++ b/util/inject.js
@@ -4,29 +4,53 @@
 var clues = require('../clues');
 
 function inject(obj, prop, $global) {
-  var keys = Object.keys(prop);
+  if (!$global)
+    throw new Error('$global not supplied to inject');
+
+  if (typeof prop !== 'object' || typeof obj !== 'object')
+    throw new Error('Invalid properties passed to inject');
+
+  var keys = [];
+  for (var key in prop)
+    keys.push(key);
 
   return clues.Promise.mapSeries(keys, function(key) {
     var path = key.split('.'),
-      base = path.length === 1 ? obj : path.slice(0, path.length - 1).join('.'),
+      base = path.slice(0, path.length - 1),
       item = path[path.length - 1],
       value = prop[key];
 
-    return clues(obj, base, $global, 'inject')
-      .then(function(base) {
-        var original = base[item];
+    var o = obj;
+
+    function nextLevel() {
+      var next = base.shift();
+      var original = o[next];
+
+      if (!next) {
+        original = o[item];
         if (original !== undefined)
-          base['original_'+item] = function private() {
+          o['original_'+item] = function private() {
             return original;
           };
         if (value.error)
           value = clues.Promise.reject(value);
-        if (base[item] && base[item]._fulfill && base[item].isPending())
-          base[item]._fulfill(value);
+        if (o[item] && o[item]._fulfill && o[item].isPending())
+          o[item]._fulfill(value);
         else
-          base[item] = value;
-      })
-      .catch(Object);
+          o[item] = value;
+      } else {
+        if (original !== undefined) 
+          o[next] = function() {
+          return clues(o,original,$global,'set','set')
+            .then(d => {
+              o = d;
+              return clues.Promise.try(o ? nextLevel : Object).then( () => d);
+            });
+        };
+      }
+    }
+
+    return nextLevel();
   })
   .then(function() {
     return obj;


### PR DESCRIPTION
Before: we had to resolve the full base prior to injecting, even though the path injected never ends up being traversed by the user. Example: injecting `a.b.c.d` would require solving `a.b.c` at the time of injection, before inserting `d`.

After:  Injection is a recursive function down the base path that is not executed unless the path is traversed by the user.  Example: injecting `a.b.c.d` would only affect `a` initially, and then affect `b` when `a` is requested etc.