### PR TITLE
Fix Frozen Objects

### DIFF
--- a/clues.js
+++ b/clues.js
@@ -163,8 +163,13 @@
     if (fn.name == 'private' || fn.name == '$private')
       value.private = true;
 
-    if (ref)
-      logic[ref] = value;
+    if (ref) try {
+      Object.defineProperty(logic,ref,{value: value, enumerable: true});
+    } catch(e) {
+      return value.then(function(value) {
+        return clues.Promise.rejected({ref : ref, message: 'Object immutable', fullref:fullref,caller: caller, stack:e.stack, value: value});
+      });
+    }
 
     return value;
     

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clues",
-  "version": "3.5.16",
+  "version": "3.5.17",
   "description": "Lightweight logic tree solver using promises.",
   "keywords": [
     "asynchronous",

--- a/test/freeze-test.js
+++ b/test/freeze-test.js
@@ -1,0 +1,50 @@
+var clues = require('../clues'),
+    assert = require('assert');
+
+describe('Frozen logic',function() {
+  var calls = 0;
+
+  var Logic = {
+    a : b => b,
+    b : () => {
+      calls++;
+      return 15;
+    }
+  };
+
+  Object.freeze(Logic);
+  describe('direct access',function() {
+    it('should not run directly ',function() {
+      return clues(Logic,'a')
+        .then(function() {
+          throw 'SHOULD_ERROR';
+        },function(e) {
+          assert.equal(e.message,'Object immutable');
+          assert.equal(e.value,15);
+          assert.equal(typeof Logic.a,'function');
+        });
+    });
+  });
+  
+  describe('cloned access',function() {
+    var facts = Object.create(Logic);
+
+    it('should resolve',function() {
+      return clues(facts,'a')
+        .then(function(a) {
+          assert.equal(a,15);
+          assert.equal(calls,2);
+          assert.equal(facts.a.value(),15);
+        });
+    });
+
+    it('should memoize',function() {
+      return clues(facts,'a')
+        .then(function(a) {
+          assert.equal(a,15);
+          assert.equal(calls,2);
+          assert.equal(facts.a.value(),15);
+        });
+    });
+  });
+});


### PR DESCRIPTION
Properties of a frozen object can not be modified and as such can not be used for clues memoization.  Properties of cloned objects from a frozen prototype (that also exist in the prototype)|can only be set with `Object.defineProperty`.   This fix safely sets the property if the logic is a clone, but throws an error if the underlying logic Object is immutable.

The current behaviour is backwards compatible but in next minor release the `Object.freeze` check will be place at the top to prevent any functions to run if logic is a frozen object.