### PR TITLE
Use defineProperty only as fallback

### DIFF
--- a/clues.js
+++ b/clues.js
@@ -163,12 +163,16 @@
     if (fn.name == 'private' || fn.name == '$private')
       value.private = true;
 
-    if (ref) try {
-      Object.defineProperty(logic,ref,{value: value, enumerable: true, configurable: true});
-    } catch(e) {
-      return value.then(function(value) {
-        return clues.Promise.rejected({ref : ref, message: 'Object immutable', fullref:fullref,caller: caller, stack:e.stack, value: value});
-      });
+    if (ref) {
+      logic[ref] = value;
+      if (logic[ref] !== value)
+        try {
+          Object.defineProperty(logic,ref,{value: value, enumerable: true, configurable: true});
+        } catch(e) {
+          return value.then(function(value) {
+            return clues.Promise.rejected({ref : ref, message: 'Object immutable', fullref:fullref,caller: caller, stack:e.stack, value: value});
+          });
+        }
     }
 
     return value;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clues",
-  "version": "3.5.18",
+  "version": "3.5.19",
   "description": "Lightweight logic tree solver using promises.",
   "keywords": [
     "asynchronous",


### PR DESCRIPTION
In most cases we would like to retain the Property Descriptors (mainly whether the property should be enumerable or not).  We therefore only use `Object.defineProperty` if the regular variable assignment failed to register (example: when logic is a clone from a frozen prototype)