### PR TITLE
Matching arguments should be from "start"

### DIFF
--- a/clues.js
+++ b/clues.js
@@ -7,8 +7,8 @@
     self.clues = clues;
   }
 
-  var reArgs = /function.*?\(([^)]*?)\).*/;
-  var reEs6 =  /\({0,1}(.*?)\){0,1}\s*=>/;
+  var reArgs = /^\s*function.*?\(([^)]*?)\).*/;
+  var reEs6 =  /^\s*\({0,1}(.*?)\){0,1}\s*=>/;
 
   function matchArgs(fn) {
     if (!fn.__args__) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clues",
-  "version": "3.5.29",
+  "version": "3.5.30",
   "description": "Lightweight logic tree solver using promises.",
   "keywords": [
     "asynchronous",

--- a/test/args-start-test.js
+++ b/test/args-start-test.js
@@ -1,0 +1,23 @@
+var clues = require('../clues'),
+    assert = require('assert');
+
+var Logic = {
+  a : 41,
+  b: 1,
+  c : a => {
+    return function(b) {
+      return a+b;
+    };
+  }
+};
+
+// Fix bug where in the example above the (b) would match as the requested arguments instead of `a`
+// This test verifies the fix
+describe('Inner function arguments',function() {
+  it('are not affecting function signature',function() {
+    return clues(Logic,'c')
+      .then(function(d) {
+        assert.equal(d,'42');
+      });
+  });
+});


### PR DESCRIPTION
Otherwise we could match arguments of an inner function as regex is tried sequentially:

Example:
```js
clues({
  a : 41,
  b: 1,
  c : a => {
    return function(b) {
      return a+b;
    };
  }
},'c');
```

Previously the matchArguments would pick `b` as the variable to solve for (as it first tried to solve for `function` and fallback to ES6).   Fixed by ensuring `^` at the start of the regex.