### PR TITLE
Add $property & $external shortcuts when sole argument to a function

### DIFF
--- a/clues.js
+++ b/clues.js
@@ -105,12 +105,14 @@
         return clues.Promise.resolve(fn);
     }
 
-    // Shortcuts to define empty objects with $property or $external
-    if (fn.name == '$property') return logic[ref] = clues.Promise.resolve({$property: fn.bind(logic)});
-    if (fn.name == '$external') return logic[ref] = clues.Promise.resolve({$external: fn.bind(logic)});
+    args = (args || matchArgs(fn));
 
-    args = (args || matchArgs(fn))
-      .map(function(arg) {
+    // Shortcuts to define empty objects with $property or $external
+    if (fn.name === '$property' || (args[0] === '$property' && args.length === 1)) return logic[ref] = clues.Promise.resolve({$property: fn.bind(logic)});
+    if (fn.name === '$external' || (args[0] === '$external' && args.length === 1)) return logic[ref] = clues.Promise.resolve({$external: fn.bind(logic)});
+
+    
+    args = args.map(function(arg) {
         var optional,showError,res;
         if (optional = (arg[0] === '_')) arg = arg.slice(1);
         if (showError = (arg[0] === '_')) arg = arg.slice(1);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clues",
-  "version": "3.5.33",
+  "version": "3.5.34",
   "description": "Lightweight logic tree solver using promises.",
   "keywords": [
     "asynchronous",

--- a/test/external-test.js
+++ b/test/external-test.js
@@ -18,6 +18,10 @@ describe('$external',function() {
     shorthandThis : function $external() {
       return this;
     },
+    as_argument: function($external) {
+      return 'answer:'+$external;
+    },
+    as_argument_es6: $external => 'answer:'+$external,
     concurrent : function $external() {
       return clues.Promise.delay(Math.random()*1000)
         .then(function() {
@@ -103,5 +107,37 @@ describe('$external',function() {
         });
     });
   });
+
+  describe('when argument name is $external',function() {
+    it('acts as a shorthand for empty object with $external',function() {
+      return clues(facts,'as_argument.first')
+        .then(function(d) {
+          assert.equal(d,'answer:first');
+          assert.equal(facts.shorthand.value().first.value(),'answer:first');
+          return clues(facts,'as_argument.second');
+        })
+        .then(function(d) {
+          assert.equal(d,'answer:second');
+          assert.equal(facts.shorthand.value().first.value(),'answer:first');
+          assert.equal(facts.shorthand.value().second.value(),'answer:second');
+        });
+    });
+
+    it('as ES6 acts as a shorthand for empty object with $external',function() {
+      return clues(facts,'as_argument_es6.first')
+        .then(function(d) {
+          assert.equal(d,'answer:first');
+          assert.equal(facts.shorthand.value().first.value(),'answer:first');
+          return clues(facts,'as_argument_es6.second');
+        })
+        .then(function(d) {
+          assert.equal(d,'answer:second');
+          assert.equal(facts.shorthand.value().first.value(),'answer:first');
+          assert.equal(facts.shorthand.value().second.value(),'answer:second');
+        });
+    });
+    
+  });
+
 
 });

--- a/test/property-test.js
+++ b/test/property-test.js
@@ -29,6 +29,10 @@ describe('$property',function() {
     shorthand : function $property(ref) {
       return +ref * this.a;
     },
+    as_argument: function ($property) {
+      return $property * this.a;
+    },
+    as_argument_es6 : a => $property => $property * a,
     concurrent : {
       $property : function() {
       return clues.Promise.delay(Math.random()*1000)
@@ -144,6 +148,36 @@ describe('$property',function() {
           assert.equal(d,10);
           assert.equal(facts.shorthand.value()['2'].value(),10);
           return clues(facts,'shorthand.4');
+        })
+        .then(function(d) {
+          assert.equal(d,20);
+          assert.equal(facts.shorthand.value()['4'].value(),20);
+          assert.equal(facts.shorthand.value()['2'].value(),10);
+        });
+    });
+  });
+
+  describe('when argument name is $property',function() {
+    it('acts as a shorthand for empty object with $property',function() {
+      return clues(facts,'as_argument.2')
+        .then(function(d) {
+          assert.equal(d,10);
+          assert.equal(facts.shorthand.value()['2'].value(),10);
+          return clues(facts,'as_argument.4');
+        })
+        .then(function(d) {
+          assert.equal(d,20);
+          assert.equal(facts.shorthand.value()['4'].value(),20);
+          assert.equal(facts.shorthand.value()['2'].value(),10);
+        });
+    });
+
+    it('as ES6 acts as a shorthand for empty object with $property',function() {
+      return clues(facts,'as_argument_es6.2')
+        .then(function(d) {
+          assert.equal(d,10);
+          assert.equal(facts.shorthand.value()['2'].value(),10);
+          return clues(facts,'as_argument_es6.4');
         })
         .then(function(d) {
           assert.equal(d,20);


### PR DESCRIPTION
`$property` and `$external` are reserved words already so this should be backwards compatible.