### PR TITLE
Add ability to add a `$prep` to service methods that get resolved as normal clues methods

### DIFF
--- a/clues.js
+++ b/clues.js
@@ -102,6 +102,9 @@
           // Pass results through clues again if its a function or an array (could be array function)
           return (typeof d == 'function' || (d && typeof d == 'object' && d.length)) ? clues(logic,d,$global,caller,fullref) : d;
         });
+      else if (typeof fn === 'function' && fn.name === '$prep') {
+        return clues(logic,fn,$global,caller,fullref).then(service => logic[ref] = service);
+      }
       else 
         return clues.Promise.resolve(fn);
     }
@@ -111,7 +114,7 @@
     // Shortcuts to define empty objects with $property or $external
     if (fn.name === '$property' || (args[0] === '$property' && args.length === 1)) return logic[ref] = clues.Promise.resolve({$property: fn.bind(logic)});
     if (fn.name === '$external' || (args[0] === '$external' && args.length === 1)) return logic[ref] = clues.Promise.resolve({$external: fn.bind(logic)});
-
+    if (fn.name === '$service') return fn;
     
     args = args.map(function(arg) {
         var optional,showError,res;

--- a/test/service-test.js
+++ b/test/service-test.js
@@ -6,7 +6,15 @@ t.test('$ as a first letter', {autoend:true}, t => {
   const Logic = {
     a : 10,
     b : 11,
+    counter: {count: 0},
     $logic_service : a => a,
+    $with_prep : function $prep(a,b,counter) {
+      counter.count++;
+      let c = a + b;
+      return function $service(d) {
+        return c + d;
+      }
+    },
     top : a => ({ $nested_service : b => a + b })
   };
 
@@ -29,6 +37,22 @@ t.test('$ as a first letter', {autoend:true}, t => {
       t.same(typeof $global_service, 'function','returns a function');
       t.same($global_service(20),20,'function works');
     },Object.create(global));
+  });
+
+  t.test('with prep', async t => {
+    const d = await clues(Object.create(Logic), '$with_prep', Object.create(global));
+    t.same(typeof d, 'function','returns a function');
+    t.same(d(5), 26);
+  });
+
+  t.test('with prep - solved only once', async t => {
+    let logic = Object.create(Logic);
+    logic.counter = {count: 0};
+    const d1 = await clues(logic, '$with_prep', Object.create(global));
+    const d2 = await clues(logic, '$with_prep', Object.create(global));
+    t.same(typeof d1, 'function','returns a function');
+    t.same(d1(5), 26);
+    t.same(logic.counter.count, 1);
   });
 
 });


### PR DESCRIPTION
I'm not a giant fan of forcing a fn named `$service`, but it allows for a lot of flexibility and is not too onerous.  

Maybe I should update the `readme` with this commit as well?