### PR TITLE
fullref: Deliminate depdencies with open-bracket

### DIFF
--- a/clues.js
+++ b/clues.js
@@ -61,7 +61,8 @@
           });
       }
 
-      fullref = (fullref ? fullref+'.' : '')+ref;
+      var separator = fullref && fullref[fullref.length-1] !== '(' && '.' || '';
+      fullref = (fullref ? fullref+separator : '')+ref;
       fn = logic ? logic[ref] : undefined;
       if (fn === undefined) {
         if (typeof(logic) === 'object' && logic !== null && (Object.getPrototypeOf(logic) || {})[ref] !== undefined)
@@ -132,7 +133,7 @@
             res = clues.Promise.resolve($global);
         }
 
-        return res || clues(logic,arg,$global,ref || 'fn',fullref)
+        return res || clues(logic,arg,$global,ref || 'fn',fullref+'(')
           .then(null,function(e) {
             if (optional) return (showError) ? e : undefined;
             else throw e;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clues",
-  "version": "3.5.45",
+  "version": "3.5.46",
   "description": "Lightweight logic tree solver using promises.",
   "keywords": [
     "asynchronous",

--- a/test/array-private-scope-test.js
+++ b/test/array-private-scope-test.js
@@ -79,7 +79,7 @@ t.test('Array fn private scope', {autoend:true}, t => {
           t.same(e.ref,'userid','userid as ref');
           t.same(e.message,'userid not defined','right error message');
           t.same(e.caller,'hash','caller is hash');
-          t.same(e.fullref,'info.public.hash.userid','fullref');
+          t.same(e.fullref,'info(public(hash(userid','fullref');
         });
     });
   });

--- a/test/caller-fullref-test.js
+++ b/test/caller-fullref-test.js
@@ -33,7 +33,7 @@ t.test('with $caller override in factsect', async t => {
 
 t.test('$fullref', async t => {
   t.same(await clues(facts,'a.b.fullref'),'a.b.fullref','direct call shows fullref');
-  t.same(await clues(facts,'fullref'),'fullref.a.b.fullref','indirect call shows fullref');
+  t.same(await clues(facts,'fullref'),'fullref(.a.b.fullref','indirect call shows fullref');
 
   const o = facts();
   o.a.b.$fullref = 'CUSTOM_FULLREF';

--- a/test/error-test.js
+++ b/test/error-test.js
@@ -132,7 +132,7 @@ t.test('error', {autoend: true},t => {
       await clues(facts,'optional',$global);
       t.same($global.error.message,'error','error passed to $logError');
       t.ok($global.error.stack,'contains a stack');
-      t.same($global.error.fullref,'optional.stack_error','fullref ok');
+      t.same($global.error.fullref,'optional(stack_error','fullref ok');
     });
 
   });

--- a/test/optional-test.js
+++ b/test/optional-test.js
@@ -50,7 +50,7 @@ t.test('optional argument', {autoend: true}, t => {
     d = await clues(facts2,'showerror');
     t.same(d.error,true);
     t.same(d.message,'#Error');
-    t.same(d.fullref,'showerror.error');
+    t.same(d.fullref,'showerror(error');
     t.same(d.ref,'error');
 
   });


### PR DESCRIPTION
Makes it easier to differentiate between object traversals vs dependencies.

Before:
`user.info.public.hash.userid`
After:
`user.info(public(hash(userid`

