### PR TITLE
Private args

### DIFF
--- a/README.md
+++ b/README.md
@@ -545,16 +545,18 @@ Similarly, a private scope can be generated in-line using a function:
 where `answer.a` = 42, but `b` is unreachable
 
 #### making anonymous functions private
-An even easier way to declare functions as private is simply [naming](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/name) them `$private` (or `private`).  Any functions named `$private` will not be accessible directly, only indirectly through a different function, as an input argument.  Specifically the  `caller` has to be a defined value and not equal to `__user__`).  Here is a quick example:
+An even easier way to declare functions as private is simply [naming](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/name) them `$private` (or `private`).  Any functions named `$private` will not be accessible directly, only indirectly through a different function, as an input argument.  Specifically the  `caller` has to be a defined value and not equal to `__user__`).  Any function or class function that has an argument `$private` will also be defined as private. Here is a quick example:
 
 ```js
 var facts = {
   a : function $private() { return 2; },
-  b : function(a) { return a+2; }
+  b : function($private, a) { return a + 1; },
+  sum : function(a,b) { return a + b; }
 };
 
-clues(facts,'b').then(console.log) // prints 4
+clues(facts,'sum').then(console.log) // prints 5
 clues(facts,'a').catch(console.log)  // prints error
+clues(facts,'b').catch(console.log)  // prints error
 ```
 
 ### Cancellability

--- a/README.md
+++ b/README.md
@@ -330,6 +330,25 @@ var Cabinet = {
 };
 ```
 
+You can also define a function as a `$prep` function by including an argument name `$prep`, which in a class definition would be something like this:
+```js
+class Cabinet {
+  something() {
+    return 5;
+  }
+
+  complicated() {
+    return 6
+  }
+
+  $adder ($prep, something, complicated) {
+    let work = something + complicated;
+    return function $service(number) {
+      return work * number;
+    }
+  }
+}
+```
 
 ### $property - lazily create children by missing reference
 If a particular property can not be found in a given object, clues will try to locate a `$property` function.  If that function exists, it is executed with the missing property name as the first argument and the missing value is set to be the function outcome.

--- a/clues.js
+++ b/clues.js
@@ -26,6 +26,8 @@
         .filter(function(d) {
           if (d === '$private')
             fn.private = true;
+          if (d === '$prep')
+            fn.prep = true;
           return d.length;
         });
     }
@@ -106,7 +108,7 @@
      return clues.Promise.reject({ref : ref, message: ref+' not defined', fullref:fullref,caller: caller, notDefined:true});
 
     // If the logic reference is not a function, we simply return the value
-    if (typeof fn !== 'function' || ((ref && ref[0] === '$') && fn.name !== '$prep')) {
+    if (typeof fn !== 'function' || ((ref && ref[0] === '$') && !fn.prep && fn.name !== '$prep')) {
       // If the value is a promise we wait for it to resolve to inspect the result
       if (fn && typeof fn.then === 'function')
         return fn.then(function(d) {
@@ -136,6 +138,8 @@
             res = clues.Promise.resolve($global);
           else if (arg === '$private')
             res = fn.private = true;
+          else if (arg === '$prep')
+            res = fn.prep = true;
         }
 
         return res || clues(logic,arg,$global,ref || 'fn',fullref+'(')

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clues",
-  "version": "3.5.48",
+  "version": "3.6.0",
   "description": "Lightweight logic tree solver using promises.",
   "keywords": [
     "asynchronous",

--- a/test/class-fn-test.js
+++ b/test/class-fn-test.js
@@ -19,8 +19,8 @@ t.test('Class functions', {autoend: true}, async t => {
     b(c) {
       return 6 + c;
     }
-    c() {
-      return 7;
+    c($private) {
+        return 7;
     }
     f(a,b,c) { return (d,e,g) => a+b+c+d+e+g;}
     met$h_od2 (  a , b   ) {
@@ -61,13 +61,10 @@ t.test('Class functions', {autoend: true}, async t => {
   });
 
   t.test('Generating instance from a class', {autoend: true}, async t => {
-    t.test('with constructor', async t => {
-      t.same(await clues(a,'class.f',$global),76);
-      t.same(await clues(b,'class.f',$global),95);
+ 
+    t.test('$private as class argument', async t => {
+      const res = await clues(a,'class.c', $global).then(() => Promise.reject('ShouldErrror'),Object);
+      t.same(res.message,'c not defined');
     });
-
-    t.test('without constructor', async t => {
-      t.same(await clues(a,'class2.a',$global),2);
-    }); 
   });
 });

--- a/test/private-test.js
+++ b/test/private-test.js
@@ -6,7 +6,7 @@ function shouldErr() { throw 'Should throw an error'; }
 
 t.test('private functions', {autoend: true}, t => {
   const Logic = {
-    M1 : function() { return Promise.delay(100,10); },
+    M1 : function($private) { return Promise.delay(100,10); },
     M2 : function $private() { return Promise.delay(20,300); },
     M3 : ['M1','M2',function private(M1,M2) { return M1+M2; }],
     M4 : function() { return Promise.delay(150,70); },
@@ -29,16 +29,26 @@ t.test('private functions', {autoend: true}, t => {
       const e = await clues(facts,'M3').catch(Object);
       t.same(e.message,'M3 not defined','errors as not defined')
       t.same(facts.M3, Logic.M3,'fn is not run');
+    });
+
+    t.test('$private argument', async t => {
+      const facts = Object.create(Logic);
+      const e = await clues(facts,'M1').catch(Object);
+      t.same(e.message,'M1 not defined','errors as not defined')
+      t.same(facts.M1, Logic.M1,'fn is not run');
     })
   });
 
   t.test('after resolution', async t => {
     const facts = Object.create(Logic);
     const MTOP = await clues(facts,'MTOP');
+    const M1 = await clues(facts,'M1').catch(Object);
     const M2 = await clues(facts,'M2').catch(Object);
     const M3 = await clues(facts,'M3').catch(Object);
 
     t.same(MTOP,380,'is available indirectly');
+    t.same(M1.message,'M1 not defined','private fn not available directly');
+    t.same(facts.M1.value(),10,'private fn promise has the resolved value');
     t.same(M2.message,'M2 not defined','private fn not available directly');
     t.same(facts.M2.value(),300,'private fn promise has the resolved value');
     t.same(M3.message,'M3 not defined','private array - not defined');

--- a/test/service-test.js
+++ b/test/service-test.js
@@ -6,14 +6,21 @@ t.test('$ as a first letter', {autoend:true}, t => {
   const Logic = {
     a : 10,
     b : 11,
-    counter: {count: 0},
+    counter: {with_prep: 0, with_prep_arg: 0},
     $logic_service : a => a,
     $with_prep : function $prep(a,b,counter) {
-      counter.count++;
+      counter.with_prep++;
       let c = a + b;
       return function $service(d) {
         return c + d;
-      }
+      };
+    },
+    $with_prep_arg : ($prep,a,b,counter) => {
+      counter.with_prep_arg++;
+      let c = a + b;
+      return function $service(d) {
+        return c + d;
+      };
     },
     top : a => ({ $nested_service : b => a + b })
   };
@@ -39,20 +46,83 @@ t.test('$ as a first letter', {autoend:true}, t => {
     },Object.create(global));
   });
 
-  t.test('with prep', async t => {
-    const d = await clues(Object.create(Logic), '$with_prep', Object.create(global));
-    t.same(typeof d, 'function','returns a function');
-    t.same(d(5), 26);
+  t.test('with function called $prep', async t => {
+    t.test('prepares a service function', async t => {
+      const d = await clues(Object.create(Logic), '$with_prep', Object.create(global));
+      t.same(typeof d, 'function','returns a function');
+      t.same(d(5), 26);
+    });
+
+    t.test('prep solved only once', async t => {
+      let logic = Object.create(Logic);
+      logic.counter = {with_prep: 0, with_prep_arg: 0};
+      const d1 = await clues(logic, '$with_prep', Object.create(global));
+      const d2 = await clues(logic, '$with_prep', Object.create(global));
+      t.same(typeof d1, 'function','returns a function');
+      t.same(d1(5), 26);
+      t.same(logic.counter.with_prep, 1);
+    });
+    t.end();
   });
 
-  t.test('with prep - solved only once', async t => {
-    let logic = Object.create(Logic);
-    logic.counter = {count: 0};
-    const d1 = await clues(logic, '$with_prep', Object.create(global));
-    const d2 = await clues(logic, '$with_prep', Object.create(global));
-    t.same(typeof d1, 'function','returns a function');
-    t.same(d1(5), 26);
-    t.same(logic.counter.count, 1);
+  t.test('with $prep as argument', async t => {
+    t.test('prepares a service function', async t => {
+      const d = await clues(Object.create(Logic), '$with_prep_arg', Object.create(global));
+      t.same(typeof d, 'function','returns a function');
+      t.same(d(5), 26);
+    });
+
+    t.test('prep solved only once', async t => {
+      let logic = Object.create(Logic);
+      logic.counter = {with_prep: 0, with_prep_arg: 0};
+      const d1 = await clues(logic, '$with_prep_arg', Object.create(global));
+      const d2 = await clues(logic, '$with_prep_arg', Object.create(global));
+      t.same(typeof d1, 'function','returns a function');
+      t.same(d1(5), 26);
+      t.same(logic.counter.with_prep_arg, 1);
+    });
+    t.end();
   });
+
+  t.test('with $prep as an argument to a class function', async t => {
+    class Test {
+      constructor(a, counter) {
+        this.a = a;
+        this.counter = counter;
+      }
+
+      $multiply($prep,a,counter) {
+        counter.with_prep_arg++;
+        return function $service(d) {
+          return d * a;
+        };
+      }
+    }
+
+    const Logic = {
+      counter: {with_prep_arg: 0},
+      a: 2,
+      test: Test
+    };
+
+    t.test('prepares a service function', async t => {
+      const d = await clues(Object.create(Logic), 'test.$multiply', Object.create(global));
+      t.same(typeof d, 'function','returns a function');
+      t.same(d(5), 10);
+    });
+
+    t.test('prep solved only once', async t => {
+      let logic = Object.create(Logic);
+      logic.counter = {with_prep_arg: 0};
+      const d1 = await clues(logic, 'test.$multiply', Object.create(global));
+      const d2 = await clues(logic, 'test.$multiply', Object.create(global));
+      t.same(typeof d1, 'function','returns a function');
+      t.same(d1(5), 10);
+      t.same(logic.counter.with_prep_arg, 1);
+    });
+    t.end();
+
+
+  })
 
 });


### PR DESCRIPTION
### Add $private and $prep as a special arguments

`$private` and `$prep` are defined using function names.  This works great when working with regular objects, where the function name can differ from the property name.   However when working with classes the property name and the function name are the same.  So to make $private or $prep you would have to return a named function `$private` or `$prep` from within the class function.

This change allows you to define a function as `$private` or `$prep` by simply including the keyword as one of the arguments:

#### $private argument

Makes the function private.  Particularly useful in class functions where you can't explicitly name the functions.

Instead of:
```js
class Test {
  secret() {
    return function $private() {
      return 42;
    }
  }
};
```
you can now do:
```js
class Test {
  secret($private) {
    return 42;
  }
};
```

#### $prep argument

Makes function a `$prep` function within a service definition.

Instead of:
```js
class Cabinet {
  constructor(something, complicated) {
    this.something = something;
    this.complicated = complicated;
  }
}

Cabinet.prototype.$adder = function $prep(something, complicated) {
    let work = something + complicated;
    return function $service(number) {
      return work * number;
    }
  }
}
```
you can do
```js
class Cabinet {
  constructor(something, complicated) {
    this.something = something;
    this.complicated = complicated;
  }

  $adder ($prep, something, complicated) {
    let work = something + complicated;
    return function $service(number) {
      return work * number;
    }
  }
}
```