### PR TITLE
Fix regex that breaks in node10

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /node_modules/
 /.nyc_output/
 /coverage/
+package-lock.json

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   node:
-    version: 7
+    version: 10
 test:
   post:
     - mv coverage/lcov-report $CIRCLE_ARTIFACTS/coverage

--- a/clues.js
+++ b/clues.js
@@ -10,7 +10,7 @@
 
   var reArgs = /^\s*function.*?\(([^)]*?)\).*/;
   var reEs6 =  /^\s*\({0,1}([^)]*?)\){0,1}\s*=>/;
-  var reEs6Class = /^\s*[a-zA-Z0-9\-$_]+\((.*?)\)\s*{/;
+  var reEs6Class = /^\s*[a-zA-Z0-9\-$_]+\s*\((.*?)\)\s*{/;
   var createEx = (e,fullref,caller,ref,value,report) => {
     if (e.fullref) return e;
     let result = {ref : e.ref || ref || fullref, message: e.message || e, fullref: e.fullref || fullref, caller: e.caller || caller, stack: e.stack || '', error: true, notDefined: e.notDefined, report: e.report || report, value: e.value || value};

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "main": "clues.js",
   "dependencies": {
-    "bluebird": "~3.5.0"
+    "bluebird": "~3.5.2"
   },
   "devDependencies": {
     "tap": "~10.3.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clues",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "Lightweight logic tree solver using promises.",
   "keywords": [
     "asynchronous",

--- a/test/cancel-test.js
+++ b/test/cancel-test.js
@@ -10,12 +10,12 @@ t.test('cancellation', {autoend: true}, async t => {
   const Logic = {
     M1 : () => new Promise(function(resolve,reject,onCancel) {
       onCancel(() => cancel.M1 = true);
-      setTimeout(() => resolve(10),130);
+      setTimeout(() => resolve(10),330);
     }),
 
     M2 : () => new Promise(function(resolve,reject,onCancel) {
       onCancel(() => cancel.M2 = true);
-      setTimeout(() => resolve(50),170);
+      setTimeout(() => resolve(50),370);
     }),
 
     M3 : () => new Promise(function(resolve,reject,onCancel) {
@@ -42,7 +42,7 @@ t.test('cancellation', {autoend: true}, async t => {
   // Cancelling in 100ms  
   setTimeout(res.cancel.bind(res),100);
 
-  await Promise.delay(200);
+  await Promise.delay(400);
 
   t.test('should not return results', t => {
     t.same(gotResults,undefined);


### PR DESCRIPTION
This only broke in node10 for some reason.