### PR TITLE
Clear up some weird undefined behavior

### DIFF
--- a/clues.js
+++ b/clues.js
@@ -19,6 +19,9 @@
   var reject = (e,fullref,caller,ref) => clues.reject(createEx(e || {},fullref,caller,ref));
   var isPromise = f => f && f.then && typeof f.then === 'function';
   var noop = d => d;
+  var undefinedPromise = clues.Promise.resolve(undefined);
+  var fakePrivate = function(){};
+  fakePrivate.private = true;
 
   function matchArgs(fn) {
     if (!fn.__args__) {
@@ -260,6 +263,10 @@
       let result = null;
       try {
         result = fn.apply(logic || {}, args);
+        if (result === undefined) {
+          result = undefinedPromise;
+          fn = fakePrivate; // private function results remain promises in `Logic`.  We don't want to modify the fn, and this is somewhat more efficient than adding another flag
+        }
       }
       catch (e) {
         // If fn is a class we solve for the constructor variables (if defined) and return a new instance

--- a/test/optional-test.js
+++ b/test/optional-test.js
@@ -13,21 +13,23 @@ t.test('optional argument', {autoend: true}, t => {
     optional_data : function(_data) { return _data; }
   };
 
-  const facts = () => Object.create(Logic);
-
   t.test('not supplied', async t => {
+    const facts = () => Object.create(Logic);
     t.same(await clues(facts,'passthrough'),undefined,'returns undefined');
   });
 
   t.test('internal default', async t => {
+    const facts = () => Object.create(Logic);
     t.same(await clues(facts,'internalize'),7,'returns the default');
   });
 
   t.test('with a set global', async t => {
+    const facts = () => Object.create(Logic);
     t.same(await clues(facts,'passthrough',{optional:10}),10,'returns global');
   });
 
   t.test('with a working function', async t => {
+    const facts = () => Object.create(Logic);
     t.same(await clues(facts,'optional_data'),5,'returns value');
   });
 

--- a/test/undefined-test.js
+++ b/test/undefined-test.js
@@ -1,0 +1,59 @@
+const clues = require('../clues');
+const Promise = require('bluebird');
+const t = require('tap');
+
+
+t.test('undefined', {autoend: true},t => {
+  
+  const Logic = {
+    a : function() { return undefined; },
+    b : undefined,
+    c : function() { return Promise.delay(1).then(() => undefined); },
+    c1 : function(a) { return 5; },
+    d1 : function(a) { return 6; },
+    c2 : function(b) { return 7; },
+    d2 : function(b) { return 8; },
+    c3 : function(c) { return 9; },
+    d3 : function(c) { return 10; },
+    
+  };
+
+  t.test('functions returning undefined are ok', {autoend:true}, t => {
+
+    t.test('immediate call', async t => {
+      const facts = Object.create(Logic);
+      const c1 = await clues(facts,'c1');
+      const d1 = await clues(facts,'d1');
+      t.same(c1, 5);
+      t.same(d1, 6);
+    });
+
+    // undefineds actually walk up the prototype chain to see if there is a function there,
+    // so try it without the undefineds
+    t.test('immediate call via assign', async t => {
+      const facts = Object.assign({}, Logic);
+      const c1 = await clues(facts,'c1');
+      const d1 = await clues(facts,'d1');
+      t.same(c1, 5);
+      t.same(d1, 6);
+    });
+
+    t.test('no fn call', async t => {
+      const facts = Object.create(Logic);
+      const c2 = await clues(facts,'c2').catch(Object);
+      const d2 = await clues(facts,'d2').catch(Object);
+      t.same(c2.message, 'b not defined');
+      t.same(d2.message, 'b not defined');
+    });
+
+    t.test('async call', async t => {
+      const facts = Object.create(Logic);
+      const c3 = await clues(facts,'c3');
+      const d3 = await clues(facts,'d3');
+      t.same(c3, 9);
+      t.same(d3, 10);
+    });
+
+
+  });
+});


### PR DESCRIPTION
Couple interesting points:

1) Functions returning `undefined` have long not been considered rejections.  They are resolved promises with a value of `undefined`
2) When we went promiseless, we introduced a situation where a non-promise function returning `undefined` would actually set the value to be `undefined` in logic which would result in a number of odd behaviors:
  a) keys that are `undefined` go up the prototype chain and will re-evaluate the parent function
  b) If there is no prototype chain, it will fail next time it is being requested.

While not perfect, I am proposing that we make functions returning success with an `undefined` mark themselves as such and behave consistent.