### PR TITLE
do not repeat logging big-e errors

### DIFF
--- a/clues.js
+++ b/clues.js
@@ -13,7 +13,7 @@
   var reEs6Class = /^\s*[a-zA-Z0-9\-$_]+\s*\((.*?)\)\s*{/;
   var createEx = (e,fullref,caller,ref,report) => {
     if (e.fullref) return e;
-    let result = {ref : e.ref || ref || fullref, message: e.message || e, fullref: e.fullref || fullref, caller: e.caller || caller, stack: e.stack || '', error: true, notDefined: e.notDefined, report: e.report || report, value: e.value, cache: e.cache};
+    let result = {ref : e.ref || ref || fullref, message: e.message || e, fullref: e.fullref || fullref, caller: e.caller || caller, stack: e.stack || '', error: true, notDefined: e.notDefined, report: e.report || report, value: e.value, cache: e.cache, cluesHasLogged: e.cluesHasLogged};
     return result;
   }; 
   var reject = (e,fullref,caller,ref) => clues.reject(createEx(e || {},fullref,caller,ref));
@@ -294,7 +294,10 @@
       hasHandledError = true;
 
       let wrappedEx = createEx(e || {}, fullref, caller, ref, true);
-      if (e && e.stack && typeof $global.$logError === 'function') $global.$logError(wrappedEx, fullref);
+      if (e && e.stack && !wrappedEx.cluesHasLogged && typeof $global.$logError === 'function') {
+        wrappedEx.cluesHasLogged = true;
+        $global.$logError(wrappedEx, fullref);
+      }
       return storeRef(logic, ref, reject(wrappedEx), fullref, caller);
     };
 

--- a/test/error-test.js
+++ b/test/error-test.js
@@ -84,6 +84,7 @@ t.test('error', {autoend: true},t => {
 
     const Global = {
       $logError : function(e,f) {
+        this.counter = (this.counter||0)+1;
         this.error = e;
         this.fullref = f;
       }
@@ -109,8 +110,21 @@ t.test('error', {autoend: true},t => {
 
       await clues(facts,'stack_error_promise',$global).then(shouldErr,Object);
       t.same($global.error.message,'error','error passed to $logError');
+      t.same($global.counter,1,'logError is called once');
       t.ok($global.error.stack,'contains a stack');
       t.same($global.error.fullref,'stack_error_promise','fullref ok');
+    });
+    t.test('promise rejected with a stack', async t => {
+      const $global = Object.create(Global);
+      const facts = {
+        stack_error_promise: ()  => clues.reject(new Error('error')),
+        reffed_error: stack_error_promise => stack_error_promise
+      };
+
+      await clues(facts,'reffed_error',$global).then(shouldErr,Object);
+      t.same($global.error.message,'error','error passed to $logError');
+      t.same($global.counter,1,'logError is called once');
+      t.ok($global.error.stack,'contains a stack');
     });
 
     t.test('error without a stack (rejection)', async t => {

--- a/test/optimization-test.js
+++ b/test/optimization-test.js
@@ -31,5 +31,6 @@ const code = `
 
 t.test('V8 compiler', async t => {
   const d = await execAsync('echo "'+code+'" | node  --allow-natives-syntax', { cwd: __dirname });
+  console.log(d);
   t.same(!!((d & 4) || (d & 16)), true);
 });


### PR DESCRIPTION
Fixes #83
```
var obj = {
   b: () => {
     throw new Error("sample");
   },
   c: b => b,
   d: c => c,
   e: d => d
}
clues(obj, 'e', { $logError: console.error } );
```

This shouldn't log 4 times